### PR TITLE
LLDP: fix wrong "const char*" issue which leads to the chassis descriptor always as the same

### DIFF
--- a/lib/ovs-lldp.c
+++ b/lib/ovs-lldp.c
@@ -203,7 +203,7 @@ aa_print_element_status_port(struct ds *ds, struct lldpd_hardware *hw)
                    &system_id_null,
                    sizeof port->p_element.system_id)) {
             const char *none_str = "<None>";
-            const char *descr = NULL;
+            char *descr = NULL;
             char *id = NULL;
             char *system;
 
@@ -226,6 +226,7 @@ aa_print_element_status_port(struct ds *ds, struct lldpd_hardware *hw)
             ds_put_format(ds, "  Auto Attach Primary Server System Id: %s\n",
                           system);
 
+            free(descr);
             free(id);
             free(system);
         }


### PR DESCRIPTION
In case multiple LLDP neighbors exist, the Rx LLDP chassis descriptors shown by the command are always the first neighbor's due to wrongly use of the "const". From the logic of the codes, the chassis ID and descriptor should be different from each neighbor. Thus the "const" should be removed.